### PR TITLE
fix: fix eslint error hint

### DIFF
--- a/example/electron-app/.eslintrc
+++ b/example/electron-app/.eslintrc
@@ -67,7 +67,9 @@
                     {
                         "allowExpressions": true
                     }
-                ]
+                ],
+                "@typescript-eslint/no-unsafe-assignment": "error",
+                "@typescript-eslint/no-unsafe-call": "error"
             }
         }
     ]


### PR DESCRIPTION
Hi,

when run example/electron-app, there will get hint error:
![image](https://github.com/user-attachments/assets/be1b963c-b213-4998-8aad-37574a63bb45)

```
Unsafe assignment of an `any` value.eslint[@typescript-eslint/no-unsafe-assignment](https://typescript-eslint.io/rules/no-unsafe-assignment)
Unsafe call of an `any` typed value.eslint[@typescript-eslint/no-unsafe-call](https://typescript-eslint.io/rules/no-unsafe-call)
```

so, there create a PR to fix it.  
